### PR TITLE
OTA: updgrade, allow setting port

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -513,7 +513,7 @@ void do_ota_upgrade(char *text)
         int port = 0;
         if (json.containsKey("port")) {
             port = json.get<int>("port");
-            Serial.print("Port configured to");
+            Serial.print("Port configured to ");
             Serial.println(port);
         }
 
@@ -813,13 +813,13 @@ void handleBH1750()
 
     if (1 <= abs(tempAmbientLight - sensorAmbientLight))
     {
-        // Print new humidity value
+        // Print new brightness value
         sensorAmbientLight = tempAmbientLight;
         Serial.print("Light: ");
         Serial.print(tempAmbientLight);
         Serial.println("Lux");
 
-        // Publish new humidity value through MQTT
+        // Publish new brightness value through MQTT
         publishSensorData("light", "light", sensorAmbientLight);
     }
 }

--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -510,16 +510,28 @@ void do_ota_upgrade(char *text)
     }
     else
     {
+        int port = 0;
+        if (json.containsKey("port")) {
+            port = json.get<int>("port");
+            Serial.print("Port configured to");
+            Serial.println(port);
+        }
+
+        if (0 >= port || 65535 < port) {
+            port = 80;
+        }
+
         String server = json.get<const char*>("server");
         String file = json.get<const char*>("file");
         Serial.print("Attempting to upgrade from ");
         Serial.print(server);
         Serial.print(":");
+        Serial.print(port);
         Serial.println(file);
         ESPhttpUpdate.setLedPin(pinAlarm, HIGH);
         WiFiClient update_client;
         t_httpUpdate_return ret = ESPhttpUpdate.update(update_client,
-                                                       server, 80, file);
+                                                       server, port, file);
         switch (ret)
         {
         case HTTP_UPDATE_FAILED:

--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -511,13 +511,15 @@ void do_ota_upgrade(char *text)
     else
     {
         int port = 0;
-        if (json.containsKey("port")) {
+        if (json.containsKey("port"))
+        {
             port = json.get<int>("port");
             Serial.print("Port configured to ");
             Serial.println(port);
         }
 
-        if (0 >= port || 65535 < port) {
+        if (0 >= port || 65535 < port)
+        {
             port = 80;
         }
 


### PR DESCRIPTION
This is just a minor improvement for the OTA upgrade. We now allow specifiying the port.

 E.g. like: 

{"file":"/anavi.bin", "server": "192.168.100.46", "port":8080}


"port" is optional in the MQTT message and port defaults to port 80, so should not break anything. 

The message format

{"file":"/anavi.bin", "server": "192.168.100.46"}

should still work

