### PR TITLE
Enable factory reset during boot

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -219,6 +219,8 @@ void setup()
     //Button
     pinMode(pinButton, INPUT);
 
+    waitForFactoryReset();
+
     // Machine ID
     calculateMachineId();
 
@@ -443,6 +445,28 @@ void setupADPS9960()
         //gesture mode will be entered once proximity mode senses something close
         apds.enableProximity(true);
         apds.enableGesture(true);
+    }
+}
+
+void waitForFactoryReset()
+{
+    Serial.println("Press button within 2 seconds for factory reset...");
+    for (int iter = 0; iter < 20; iter++)
+    {
+        digitalWrite(pinAlarm, HIGH);
+        delay(50);
+        if (false == digitalRead(pinButton))
+        {
+            factoryReset();
+            return;
+        }
+        digitalWrite(pinAlarm, LOW);
+        delay(50);
+        if (false == digitalRead(pinButton))
+        {
+            factoryReset();
+            return;
+        }
     }
 }
 


### PR DESCRIPTION
The factory reset button only works once the Anavi Thermometer has
successfully connected to a network.  This is problematic if you move
the thermometer to another location.  While the Thermometer will fall
back to the normal network setup if it cannot connect, I have found
that the setup works better when the thermometer has been reset.

This commit blinks rapidly with the status led for 2 seconds during
setup.  If you press the reset button during this time, the normal
factory reset sequence will be started: keep holding the button for 3
seconds while it blinks slowly, and it will apply the factory
settings.