### PR TITLE
Avoid printing "beginPublish failed!" after a failed OTA upgrade

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -594,6 +594,11 @@ void mqttCallback(char* topic, byte* payload, unsigned int length)
     {
         Serial.println("OTA request seen.\n");
         do_ota_upgrade(text);
+        // Any OTA upgrade will stop the mqtt client, so if the
+        // upgrade failed and we get here publishState() will fail.
+        // Just return here, and we will reconnect from within the
+        // loop().
+        return;
     }
 
     publishState();


### PR DESCRIPTION
The OTA upgrade will stop the mqtt client.  Make sure we don't try to
publish any messages while it is stopped.