### PR TITLE
Prevent buffer overruns in json.printTo

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -857,7 +857,7 @@ void publishSensorData(const char* subTopic, const char* key, const float value)
     char payload[100];
     JsonObject& json = jsonBuffer.createObject();
     json[key] = value;
-    json.printTo((char*)payload, json.measureLength() + 1);
+    json.printTo(payload);
     char topic[200];
     sprintf(topic,"%s/%s/%s", workgroup, machineId, subTopic);
     mqttClient.publish(topic, payload, true);
@@ -869,7 +869,7 @@ void publishSensorData(const char* subTopic, const char* key, const String& valu
     char payload[100];
     JsonObject& json = jsonBuffer.createObject();
     json[key] = value;
-    json.printTo((char*)payload, json.measureLength() + 1);
+    json.printTo(payload);
     char topic[200];
     sprintf(topic,"%s/%s/%s", workgroup, machineId, subTopic);
     mqttClient.publish(topic, payload, true);


### PR DESCRIPTION
When json.printTo is invoked with a char* and an int, the int should
describe how big the buffer is.  The ArduinoJson library won't write
more than fits in the buffer.

The json.measureLength() method can be used to calculate how large the
buffer needs to be, and you can then allocate a suitably large buffer.
But in our case, a buffer of 100 bytes is surely large enough, so
there is no need for dynamic allocation.

By just passing a char array to printTo, it will automatically use the
size of the buffer to avoid buffer overruns.  (Alternatively, we could
have used sizeof(payload) as the second argument of json.printTo.)