### PR TITLE
 Create a device and entity for Home Assistant MQTT Discovery

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -787,9 +787,26 @@ bool publishSensorDiscovery(const char *config_key,
     JsonObject& json = jsonBuffer.createObject();
     json["device_class"] = device_class;
     json["name"] = String(ha_name) + " " + name_suffix;
+    json["unique_id"] = String("anavi-") + machineId + "-" + config_key;
     json["state_topic"] = String(workgroup) + "/" + machineId + state_topic;
     json["unit_of_measurement"] = unit;
     json["value_template"] = value_template;
+
+    JsonObject& device = jsonBuffer.createObject();
+
+    device["identifiers"] = machineId;
+    device["manufacturer"] = "ANAVI Technology";
+    device["model"] = "ANAVI Thermometer";
+    device["name"] = ha_name;
+    device["sw_version"] = ESP.getSketchMD5();
+
+    JsonArray& conns = jsonBuffer.createArray();
+    JsonArray& pair = conns.createNestedArray();
+    pair.add("mac");
+    pair.add(WiFi.macAddress());
+    device["connections"] = conns;
+
+    json["device"] = device;
 
     int payload_len = json.measureLength();
     if (!mqttClient.beginPublish(topic, payload_len, true))


### PR DESCRIPTION
By including the "device" and "unique_id" elements in the MQTT Discovery message, Home Assistant will create a "device" and "entity" for the sensor.  This makes it show up as a device under the MQTT integration, which means you will be able to set the area of the thermometer (if you are using a recent enough version of Home Assistant).

I also refactored the code that sends the Discovery messages, so that it uses the ArduinoJson library. This results in cleaner code and less code duplication. I really should have used ArduinoJson from the start instead of having hardcoded string templates for the JSON messages.