### PR TITLE
Handle missing temp_scale in /config.json

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -327,7 +327,12 @@ void setup()
                     strcpy(workgroup, json["workgroup"]);
                     strcpy(username, json["username"]);
                     strcpy(password, json["password"]);
-                    strcpy(temp_scale, json["temp_scale"]);
+                    {
+                        const char *s = json.get<const char*>("temp_scale");
+                        if (!s)
+                            s = "celsius";
+                        strcpy(temp_scale, s);
+                    }
 #ifdef HOME_ASSISTANT_DISCOVERY
                     {
                         const char *s = json.get<const char*>("ha_name");


### PR DESCRIPTION
Let the temperature scale default to celsius if it is missing in
/config.json, instead of crashing.  This is needed for graceful
upgrades of already configured thermometers.