### PR TITLE
Support ESP12_BLUE_LED_ALWAYS_ON

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -31,6 +31,35 @@
 #define OTA_UPGRADES 1
 // #define OTA_SERVER "www.example.com"
 
+// The GPIO2 pin is connected to two things on the ANAVI Thermometer:
+//
+// - Internally on the ESP-12E module, it is connected to a blue
+//   status LED, that lights up whenever the pin is driven low.
+//
+// - On the ANAVI Thermometer board, it is connected to the DHT22
+//   temperature and humidity sensor.  Whenever a measurements is
+//   made, both the ESP8266 on the ESP-12E module and the DHT22 sensor
+//   drives the pin low.  One measurement drives it low several times:
+//
+//      - At least 1 ms by the ESP8266 to start the measurement.
+//      - 80 us by the DHT22 to acknowledge
+//      - 50 us by the DHT22 for each bit transmitted, a total of 40 times
+//
+//   In total, this means it is driven low more than 3 ms for each
+//   measurement.  This results in a blue flash from the status LED
+//   that is clearly visible, especially in a dark room.
+//
+// Unfortunately, there seems to be no way to get rid of this blue
+// flash in software.  But we can mask it by turning on the blue LED
+// all the time.  The human eye won't detect that it is turned off
+// briefly during the measurement.  Technically, we still follow the
+// letter of the data sheet, as that only requires the start pulse to
+// be "at least 1-10 ms", and 10 seconds is clearly "at least 10
+// ms". :-)
+//
+// This hack will likely increase the power consumption slightly.
+// #define ESP12_BLUE_LED_ALWAYS_ON
+
 #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
 #include <ESP8266httpUpdate.h>
 
@@ -1162,6 +1191,12 @@ void loop()
         // Read temperature and humidity from DHT22/AM2302
         float temp = dht.readTemperature();
         float humidity = dht.readHumidity();
+
+#ifdef ESP12_BLUE_LED_ALWAYS_ON
+        pinMode(DHTPIN, OUTPUT);
+        digitalWrite(DHTPIN, LOW);
+#endif
+
         if (!isnan(humidity) && !isnan(temp))
         {
             // Adjust temperature depending on the calibration coefficient


### PR DESCRIPTION
I find the blinking blue LED on the ESP-12 to be a bit annoying at night.
I was trying to disable it, but that seems impossible unless you also disable
reading the temperature and humidity, and that would defeat the purpose
of the device. :-)  This is the best solution I've come up with.  Please check
what I have written -- I would love it if I have misunderstood something
and it actually is possible to turn off the blue LED.

If you are annoyed by the flashing blue LED on the ANAVI Thermometer,
you can now define ESP12_BLUE_LED_ALWAYS_ON to enable a hack that will
instead make it be almost always on.  It will still flicker while a
temperature measurement is made, but so quickly that the human eye
can't detect it.

Also documented why the blue LED blinks in the first place.