### PR TITLE
Fix OTA upgrades for ArduinoJson 6

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -682,11 +682,11 @@ void do_ota_upgrade(char *text)
     {
         Serial.println("No success decoding JSON.\n");
     }
-    else if (!json["server"])
+    else if (!json.containsKey("server"))
     {
         Serial.println("JSON is missing server\n");
     }
-    else if (!json["file"])
+    else if (!json.containsKey("file"))
     {
         Serial.println("JSON is missing file\n");
     }


### PR DESCRIPTION
The recent upgrade to ArduinoJson 6 unfortunately broke OTA upgrades,
becuse the method used to check if the server and file is present no
longer works in ArduinoJson 6.  Fix.