### PR TITLE
Include the machineId in the config access point name

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -483,7 +483,8 @@ void setup()
     //if it does not connect it starts an access point with the specified name
     //here  "AutoConnectAP"
     //and goes into a blocking loop awaiting configuration
-    if (!wifiManager.autoConnect("ANAVI Thermometer", ""))
+    String ap_ssid = String("ANAVI Thermometer ") + String(machineId);
+    if (!wifiManager.autoConnect(ap_ssid.c_str(), ""))
     {
         digitalWrite(pinAlarm, LOW);
         Serial.println("failed to connect and hit timeout");


### PR DESCRIPTION
If you have multiple ANAVI Thermometer devices, this can greatly
simplify figuring out which of them that is unconfigured.  It also
makes the connection more stable, as you won't have a connection that
alters between them.