### PR TITLE
Ensure we are in station mode after a successful connect

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -493,6 +493,7 @@ void setup()
         ESP.reset();
         delay(5000);
     }
+    WiFi.mode(WIFI_STA);
 
     //if you get here you have connected to the WiFi
     Serial.println("connected...yeey :)");


### PR DESCRIPTION
On rare occasions (when the AP and the thermometer are switched on at
the same time, and the timing is just right), the autoConnect might
leave us in the station + access point mode.  We don't want that.
Explicitly set the mode to WIFI_STA.