### PR TITLE
Use ESP.restart() instead of ESP.reset() on failed WiFi

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -588,7 +588,7 @@ void setup()
         Serial.println("failed to connect and hit timeout");
         delay(3000);
         //reset and try again, or maybe put it to deep sleep
-        ESP.reset();
+        ESP.restart();
         delay(5000);
     }
     WiFi.mode(WIFI_STA);


### PR DESCRIPTION
This seems to do a better job of restarting the device, and it seems
many sites on the net proposes to use ESP.restart().