### PR TITLE
Fix HA Discovery: each device needs to be unique

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -1135,7 +1135,7 @@ bool publishSensorDiscovery(const char *component,
     json["device"]["identifiers"] = machineId;
     json["device"]["manufacturer"] = "ANAVI Technology";
     json["device"]["model"] = "ANAVI Thermometer";
-    json["device"]["name"] = ha_name;
+    json["device"]["name"] = String(ha_name) + " " + name_suffix;
     json["device"]["sw_version"] = ESP.getSketchMD5();
 
     JsonArray connections = json["device"].createNestedArray("connections").createNestedArray();


### PR DESCRIPTION
Home Assistant seems to get confused when the temperature sensor and
pressure sensor have exactly the same device information.  By
appending the name suffix to the name, things seem to work better.

I'm not 100% sure this is the correct thing to do, though.  I have not
been able to find a resource that explains the relationship between
devices, entities, the state machine, and MQTT Discovery in a way that
I fully understand.  That said, this seems to work better.