### PR TITLE
Publish the amount of free heap memory via MQTT

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -118,6 +118,13 @@
 // by mistake.
 #undef OTA_FACTORY_RESET
 
+// Define to PUBLISH_FREE_HEAP publish the amount of free heap space
+// to MQTT, as <workgroup>/<machineid>/free-heap, with a value on
+// this format:
+//
+//     { "bytes": 32109 }
+#define PUBLISH_FREE_HEAP
+
 #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
 #include <ESP8266httpUpdate.h>
 
@@ -1659,6 +1666,10 @@ void loop()
         char chipid[9];
         snprintf(chipid, sizeof(chipid), "%08x", ESP.getChipId());
         publishSensorData("chipid", "chipid", chipid);
+#endif
+
+#ifdef PUBLISH_FREE_HEAP
+        publishSensorData("free-heap", "bytes", ESP.getFreeHeap());
 #endif
     }
 


### PR DESCRIPTION
I have a vacation house, 2 hours drive by car from where I live,
with 9 ANAVI Thermometers.  One of the is located in the
basement, and it has a real poor WiFi connection.  The reported
RSSI is around -80.  All the other thermometers report -37 to
-68.  I'm not that surprised to see that the basement thermometer
repeatedly loses its connection to the MQTT broker, and
reconnects a few seconds or minutes later.

Despite the bad connection, I managed to get data from the
basement thermometer for almost two weeks.  Then it stopped
reporting the temperature.  I still see it publishing a few MQTT
topics, but only once, and it never gets around to the
temperature or humidity.  A few times, I've seen it publish the
message "{}" to the MQTT autodiscovery topic -- something that
should never happen, unless perhaps it is running out of memory.

All of this makes me suspect that there is a memory leak
somewhere that is only triggered when you have a really bad WiFi
connection.  So I'd like to see how much free heap there is, to
aid in the debugging of this issue.

(I've also ordered a new WiFi mesh router, so that I can improve
my WiFi coverage.)