### PR TITLE
Don't tell Home Assistant to round the humidity value

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -1329,7 +1329,7 @@ void publishState()
                            "Humidity",
                            "/air/humidity",
                            "%",
-                           "{{ value_json.humidity | round(0) }}");
+                           "{{ value_json.humidity }}");
 
     if (haveButton)
     {


### PR DESCRIPTION
When using the value to draw a graph of e.g. the humidity of a crawl
space where you have a dehumidifier installed, the graph becomes very
bumpy if you round the value to whole percentages.  You get a smoother
graph if you allow the value to include the decimal as well, and can
detect trends earlier.