### PR TITLE
Home Assistant MQTT Discovery: set state_class for all sensors

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -2105,6 +2105,9 @@ bool publishSensorDiscovery(const char *component,
     json["name"] = String(ha_name) + " " + name_suffix;
     json["unique_id"] = String("anavi-") + machineId + "-" + config_key;
     json["state_topic"] = String(workgroup) + "/" + machineId + "/" + state_topic;
+    if (strcmp(component, "sensor") == 0)
+        json["state_class"] = "measurement";
+
     if (unit)
         json["unit_of_measurement"] = unit;
     json["value_template"] = value_template;


### PR DESCRIPTION
By setting the state_class to "measurement", we ensure that the Long-term Statistics feature of Home Assistant stores our measurements.