### PR TITLE
Handle ArduinoJson 6.19.0 and newer; recommend 6.21.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can [build and upload the sketch through the Arduino IDE](https://www.youtub
 The default firmware of ANAVI Thermometer depends on the following Arduino libraries, which must be added in the Arduino IDE before compiling the sketch.
 
 * [WiFiManager by tzapu](https://github.com/tzapu/WiFiManager) (version 0.15.0)
-* [ArduinoJson by Benoit Blanchon](https://arduinojson.org/) (version 6.11.2)
+* [ArduinoJson by Benoit Blanchon](https://arduinojson.org/) (version 6.21.4)
 * [PubSubClient by Nick O'Leary](https://pubsubclient.knolleary.net/) (version 2.7.0)
 * [Adafruit HTU21DF Library by Adafruit](https://github.com/adafruit/Adafruit_HTU21DF_Library) (version 1.0.1)
 * [Adafruit APDS9960 Library by Adafruit](https://github.com/adafruit/Adafruit_APDS9960) (version 1.0.5)

--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -364,6 +364,12 @@
 #include <ESP8266WebServer.h>
 #include <WiFiManager.h> //https://github.com/tzapu/WiFiManager
 
+// ArduinoJson 6.19.0 changes the default for this setting to 1.  This
+// leads to serialisations such as {"BMPtemperature":21.20000076}
+// instead of the more sane {"BMPtemperature":21.2}.  The
+// documentation suggests we should use double instead of float, but
+// just restoring the old default value is a simpler fix.
+#define ARDUINOJSON_USE_DOUBLE 0
 #include <ArduinoJson.h> //https://github.com/bblanchon/ArduinoJson
 
 #include <PubSubClient.h> //https://github.com/knolleary/pubsubclient


### PR DESCRIPTION
ArduinoJson 6.19.0 uses double instead of float by default.  This causes serialized floats to sometimes contain trailing digits that are rounding errors.  For instance, 21.2 might be sent as "21.20000076". Fix by defining ARDUINOJSON_USE_DOUBLE to 0, which was the default value in older versions of ArduinoJson.

Change the recommended version to the current release: 6.21.4.