### PR TITLE
Recover from stuck DHT22 all-zero readings

### DIFF
--- a/anavi-thermometer-sw/anavi-thermometer-sw.ino
+++ b/anavi-thermometer-sw/anavi-thermometer-sw.ino
@@ -423,6 +423,12 @@ const int pinButton = 0;
 unsigned long sensorPreviousMillis = 0;
 const long sensorInterval = 10000;
 
+// A stuck DHT22 can return a checksum-valid frame containing only zeroes.
+// Treat several consecutive all-zero frames as a sensor failure instead of
+// replacing the last valid measurement with 0 C and 0% humidity.  See #49.
+const uint8_t dht22ZeroReadRestartThreshold = 3;
+uint8_t dht22ConsecutiveZeroReadings = 0;
+
 bool haveButton = false;
 
 class ButtonState
@@ -3995,8 +4001,31 @@ void loop()
         digitalWrite(DHTPIN, LOW);
 #endif
 
-        if (!isnan(humidity) && !isnan(temp))
+        const bool dht22ReadSucceeded = !isnan(humidity) && !isnan(temp);
+        const bool dht22ReadAllZeroes = dht22ReadSucceeded &&
+                                        temp == 0.0f && humidity == 0.0f;
+
+        if (dht22ReadAllZeroes)
         {
+            if (dht22ConsecutiveZeroReadings < dht22ZeroReadRestartThreshold)
+                dht22ConsecutiveZeroReadings++;
+
+            Serial.print("DHT22 returned an all-zero reading (");
+            Serial.print(dht22ConsecutiveZeroReadings);
+            Serial.print("/");
+            Serial.print(dht22ZeroReadRestartThreshold);
+            Serial.println("). Keeping the last valid measurement.");
+            mqtt_status(MQTT_DHT22)->offline();
+
+            if (dht22ConsecutiveZeroReadings >= dht22ZeroReadRestartThreshold)
+            {
+                Serial.println("DHT22 remains stuck. Restarting to recover it.");
+                nice_restart();
+            }
+        }
+        else if (dht22ReadSucceeded)
+        {
+            dht22ConsecutiveZeroReadings = 0;
             mqtt_online(MQTT_DHT22);
 
             // Adjust temperature depending on the calibration coefficient
@@ -4018,6 +4047,7 @@ void loop()
         }
         else
         {
+            dht22ConsecutiveZeroReadings = 0;
             mqtt_status(MQTT_DHT22)->offline();
         }
 


### PR DESCRIPTION
Fixes #49.

A stuck DHT22 can produce an all-zero data frame. Its checksum is also zero, so the DHT library accepts the frame and the firmware replaces the last valid values with 0 C and 0% humidity. Those values then remain on the OLED and retained MQTT topics.

This change:

- recognizes only the combined 0 C and 0% RH reading as the corrupt all-zero frame
- keeps the last valid values instead of publishing or displaying zeroes
- marks the DHT22 MQTT status offline while recovery is pending
- invokes the existing nice_restart() recovery after three consecutive all-zero samples
- resets the failure counter after either a valid non-zero sample or a normal read failure

A temperature of 0 C with non-zero humidity remains valid.

Validation:

- git diff --check
- arduino-cli compile --fqbn esp8266:esp8266:generic:eesz=4M1M --warnings all anavi-thermometer-sw
- ESP8266 core 3.1.2 and the dependency versions documented on master

The compile succeeds. Reported warnings are pre-existing warnings in the sketch and dependencies.